### PR TITLE
Move future work docs from root to impl/c/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,3 @@ These apply to ALL implementations regardless of language:
 - All implementations must target RFC 8391 including Errata 7900.
 - Secret-dependent branches and memory accesses must be constant-time. Verification uses constant-time comparison. Annotate any deviations.
 - No implementation should depend on `third_party/xmss-reference/` at build time -- it is a development reference only.
-
-## Future work
-
-- **Remaining-signatures query**: Sign functions return exhaustion errors but there is no function to query how many signatures remain.
-- **XMSS-MT KAT**: Cross-validation against xmss-reference for XMSS-MT parameter sets (the reference embeds BDS state in the SK buffer, so byte-level comparison requires a translation layer).

--- a/impl/c/CLAUDE.md
+++ b/impl/c/CLAUDE.md
@@ -123,3 +123,8 @@ These are enforced and must not be broken by any change:
 ## Dependencies
 
 None at runtime. Build requires CMake >= 3.16 and a C99 compiler.
+
+## Future work
+
+- **Remaining-signatures query**: Sign functions return exhaustion errors but there is no function to query how many signatures remain.
+- **XMSS-MT KAT**: Cross-validation against xmss-reference for XMSS-MT parameter sets (the reference embeds BDS state in the SK buffer, so byte-level comparison requires a translation layer).


### PR DESCRIPTION
Both items (remaining-signatures query and XMSS-MT KAT) are specific
to the C implementation, so they belong in its CLAUDE.md rather than
the top-level one.

https://claude.ai/code/session_01T4JrpfW7s55SRniFcqGEjD