### PR TITLE
Fix missing bds_k validation (#12, #18)

### DIFF
--- a/impl/c/include/xmss/xmss.h
+++ b/impl/c/include/xmss/xmss.h
@@ -33,6 +33,24 @@
 #define XMSS_ERR_EXHAUSTED (-4)  /* key index exhausted */
 
 /**
+ * xmss_xmss_bds_k_valid() - Validate a BDS retain parameter.
+ *
+ * K=0 is always valid (no retain optimisation).  Non-zero K requires:
+ *   K <= XMSS_MAX_BDS_K, K >= 2, K < tree_height, (tree_height - K) even.
+ *
+ * The XMSS_MAX_BDS_K bound ensures the retain array (sized for MAX_BDS_K)
+ * is never overflowed.
+ */
+static inline int xmss_bds_k_valid(const xmss_params *p, uint32_t bds_k)
+{
+    if (bds_k == 0) return 1;
+    return bds_k <= XMSS_MAX_BDS_K &&
+           bds_k >= 2 &&
+           bds_k < p->tree_height &&
+           (p->tree_height - bds_k) % 2 == 0;
+}
+
+/**
  * Entropy callback type.
  *
  * The caller supplies a function that fills buf[0..len-1] with len bytes of
@@ -103,6 +121,8 @@ typedef struct xmss_bds_state {
                    ((1U << XMSS_MAX_BDS_K) - XMSS_MAX_BDS_K - 1) : 1][XMSS_MAX_N];
 
     uint32_t next_leaf;  /* next leaf to compute during state_update */
+
+    uint32_t bds_k;      /* retain parameter used at keygen (for sign-time mismatch detection) */
 } xmss_bds_state;
 
 /**
@@ -116,8 +136,8 @@ typedef struct xmss_bds_state {
  * @sk:          Output secret key (p->sk_bytes bytes).
  * @state:       Output BDS state (caller-allocated).
  * @bds_k:       BDS retain parameter. K=0 always valid (no retain
- *               optimisation). Non-zero K requires: K >= 2, K < tree_height,
- *               and (tree_height - K) even (BDS algorithm precondition).
+ *               optimisation). Non-zero K requires: K <= XMSS_MAX_BDS_K,
+ *               K >= 2, K < tree_height, and (tree_height - K) even.
  * @randombytes: Caller-supplied entropy function.
  *
  * Returns XMSS_OK on success, XMSS_ERR_PARAMS if bds_k is invalid.
@@ -144,8 +164,10 @@ int xmss_keygen(const xmss_params *p, uint8_t *pk, uint8_t *sk,
  * @sk:     Secret key (p->sk_bytes bytes); leaf index incremented in place.
  * @state:  BDS state (updated in place).
  * @bds_k:  Retain parameter (same value used in xmss_keygen).
+ *           Must satisfy xmss_bds_k_valid() and match the value stored in state.
  *
- * Returns XMSS_OK on success, XMSS_ERR_EXHAUSTED if key index exhausted.
+ * Returns XMSS_OK on success, XMSS_ERR_PARAMS if bds_k is invalid or
+ * mismatches the keygen value, XMSS_ERR_EXHAUSTED if key index exhausted.
  *
  * The leaf index in sk is incremented BEFORE returning to the caller.
  * Callers must persist the updated sk immediately to prevent index reuse.
@@ -246,7 +268,8 @@ typedef struct xmss_mt_state {
  * @sk:          Output secret key (p->sk_bytes bytes).
  * @state:       Output hypertree state (caller-allocated).
  * @bds_k:       BDS retain parameter. K=0 always valid. Non-zero K requires:
- *               K >= 2, K < tree_height, and (tree_height - K) even.
+ *               K <= XMSS_MAX_BDS_K, K >= 2, K < tree_height,
+ *               and (tree_height - K) even.
  * @randombytes: Caller-supplied entropy function.
  *
  * Returns XMSS_OK on success.
@@ -265,8 +288,10 @@ int xmss_mt_keygen(const xmss_params *p, uint8_t *pk, uint8_t *sk,
  * @sk:     Secret key (p->sk_bytes bytes); index incremented in place.
  * @state:  Hypertree state (updated in place).
  * @bds_k:  BDS retain parameter (same value used in keygen).
+ *           Must satisfy xmss_bds_k_valid() and match the value stored in state.
  *
- * Returns XMSS_OK on success, XMSS_ERR_EXHAUSTED if index exhausted.
+ * Returns XMSS_OK on success, XMSS_ERR_PARAMS if bds_k is invalid or
+ * mismatches the keygen value, XMSS_ERR_EXHAUSTED if index exhausted.
  */
 int xmss_mt_sign(const xmss_params *p, uint8_t *sig,
                 const uint8_t *msg, size_t msglen,

--- a/impl/c/src/bds_serialize.c
+++ b/impl/c/src/bds_serialize.c
@@ -6,6 +6,7 @@
  *
  * No malloc (J3), no VLAs (J1), no recursion (J4), no function pointers (J2).
  */
+#include <assert.h>
 #include <string.h>
 #include <stdint.h>
 
@@ -29,6 +30,7 @@ static uint32_t retain_count(uint32_t bds_k)
 
 uint32_t xmss_bds_serialized_size(const xmss_params *p, uint32_t bds_k)
 {
+    assert(xmss_bds_k_valid(p, bds_k));
     uint32_t n = p->n;
     uint32_t h = p->tree_height;
     uint32_t th_count = h - bds_k;
@@ -47,6 +49,8 @@ uint32_t xmss_bds_serialized_size(const xmss_params *p, uint32_t bds_k)
 int xmss_bds_serialize(const xmss_params *p, uint8_t *buf,
                        const xmss_bds_state *state, uint32_t bds_k)
 {
+    if (!xmss_bds_k_valid(p, bds_k)) { return XMSS_ERR_PARAMS; }
+
     uint32_t n = p->n;
     uint32_t h = p->tree_height;
     uint32_t th_count = h - bds_k;
@@ -109,6 +113,8 @@ int xmss_bds_serialize(const xmss_params *p, uint8_t *buf,
 int xmss_bds_deserialize(const xmss_params *p, xmss_bds_state *state,
                          const uint8_t *buf, uint32_t bds_k)
 {
+    if (!xmss_bds_k_valid(p, bds_k)) { return XMSS_ERR_PARAMS; }
+
     uint32_t n = p->n;
     uint32_t h = p->tree_height;
     uint32_t th_count = h - bds_k;
@@ -118,6 +124,7 @@ int xmss_bds_deserialize(const xmss_params *p, xmss_bds_state *state,
 
     /* Zero entire state to clear MAX-sized padding */
     memset(state, 0, sizeof(xmss_bds_state));
+    state->bds_k = bds_k;
 
     /* auth */
     for (i = 0; i < h; i++) {

--- a/impl/c/src/xmss.c
+++ b/impl/c/src/xmss.c
@@ -227,10 +227,8 @@ int xmss_keygen(const xmss_params *p, uint8_t *pk, uint8_t *sk,
     xmss_adrs_t adrs;
     int ret;
 
-    /* Validate bds_k: K=0 always valid; non-zero K requires K >= 2,
-     * K < H, and (H - K) even (BDS algorithm precondition). */
-    if (bds_k != 0 && (bds_k >= p->tree_height || bds_k < 2 ||
-                        (p->tree_height - bds_k) % 2)) {
+    /* Validate bds_k (includes XMSS_MAX_BDS_K upper bound check) */
+    if (!xmss_bds_k_valid(p, bds_k)) {
         return XMSS_ERR_PARAMS;
     }
 
@@ -240,6 +238,7 @@ int xmss_keygen(const xmss_params *p, uint8_t *pk, uint8_t *sk,
 
     /* Zero the BDS state */
     memset(state, 0, sizeof(*state));
+    state->bds_k = bds_k;
 
     /* Compute tree root with BDS state capture */
     memset(&adrs, 0, sizeof(adrs));
@@ -285,6 +284,10 @@ int xmss_sign(const xmss_params *p, uint8_t *sig,
     const uint8_t *sk_prf   = sk + sk_off_prf(p);
     const uint8_t *root     = sk + sk_off_root(p);
     const uint8_t *pub_seed = sk + sk_off_pub_seed(p);
+
+    /* Validate bds_k and check for keygen/sign mismatch */
+    if (!xmss_bds_k_valid(p, bds_k)) { return XMSS_ERR_PARAMS; }
+    if (bds_k != state->bds_k) { return XMSS_ERR_PARAMS; }
 
     /* Read current index */
     idx = bytes_to_ull(sk + sk_off_idx(p), p->idx_bytes);

--- a/impl/c/src/xmss_mt.c
+++ b/impl/c/src/xmss_mt.c
@@ -54,10 +54,8 @@ int xmss_mt_keygen(const xmss_params *p, uint8_t *pk, uint8_t *sk,
     if (p->d < 2 || p->d > XMSS_MAX_D) {
         return XMSS_ERR_PARAMS;
     }
-    /* Validate bds_k: K=0 always valid; non-zero K requires K >= 2,
-     * K < H, and (H - K) even (BDS algorithm precondition). */
-    if (bds_k != 0 && (bds_k >= p->tree_height || bds_k < 2 ||
-                        (p->tree_height - bds_k) % 2)) {
+    /* Validate bds_k (includes XMSS_MAX_BDS_K upper bound check) */
+    if (!xmss_bds_k_valid(p, bds_k)) {
         return XMSS_ERR_PARAMS;
     }
 
@@ -67,6 +65,11 @@ int xmss_mt_keygen(const xmss_params *p, uint8_t *pk, uint8_t *sk,
 
     /* Zero entire state */
     memset(state, 0, sizeof(*state));
+
+    /* Set bds_k on all BDS states (2*d-1 total) */
+    for (i = 0; i < 2 * p->d - 1; i++) {
+        state->bds[i].bds_k = bds_k;
+    }
 
     /* Build trees bottom-up, signing each root at the layer above */
     memset(&adrs, 0, sizeof(adrs));
@@ -152,6 +155,10 @@ int xmss_mt_sign(const xmss_params *p, uint8_t *sig,
     const uint8_t *sk_prf   = sk + sk_off_prf(p);
     const uint8_t *root     = sk + sk_off_root(p);
     const uint8_t *pub_seed = sk + sk_off_pub_seed(p);
+
+    /* Validate bds_k and check for keygen/sign mismatch */
+    if (!xmss_bds_k_valid(p, bds_k)) { return XMSS_ERR_PARAMS; }
+    if (bds_k != state->bds[0].bds_k) { return XMSS_ERR_PARAMS; }
 
     /* Read current index */
     idx = bytes_to_ull(sk + sk_off_idx(p), p->idx_bytes);

--- a/impl/c/test/test_bds.c
+++ b/impl/c/test/test_bds.c
@@ -31,6 +31,11 @@ static void test_bds_k_validation(void)
     rc = xmss_keygen(&t.p, t.pk, t.sk, t.state, 12, test_randombytes);
     TEST("bds_k=12 (>h) rejected", rc == XMSS_ERR_PARAMS);
 
+    /* Issue #12: bds_k exceeding XMSS_MAX_BDS_K must be rejected even if
+     * it passes the other checks (>= 2, < H, (H-K) even). */
+    rc = xmss_keygen(&t.p, t.pk, t.sk, t.state, XMSS_MAX_BDS_K + 2, test_randombytes);
+    TEST("bds_k=MAX_BDS_K+2 (>MAX_BDS_K) rejected", rc == XMSS_ERR_PARAMS);
+
     test_rng_reset(1);
     rc = xmss_keygen(&t.p, t.pk, t.sk, t.state, 0, test_randombytes);
     TEST("bds_k=0 accepted", rc == XMSS_OK);
@@ -106,12 +111,116 @@ static void test_sequential_k(uint32_t oid, const char *name, uint32_t bds_k)
     xmss_test_ctx_free(&t);
 }
 
+/* ------------------------------------------------------------------ */
+/* Issue #18: sign with mismatched bds_k must be rejected             */
+/* ------------------------------------------------------------------ */
+static void test_bds_k_sign_mismatch(void)
+{
+    xmss_test_ctx t;
+    uint8_t msg[] = { 0x01, 0x02 };
+    int rc;
+
+    xmss_test_ctx_init(&t, OID_XMSS_SHA2_10_256);
+
+    /* Keygen with K=0, sign with K=2 */
+    test_rng_reset(10);
+    rc = xmss_keygen(&t.p, t.pk, t.sk, t.state, 0, test_randombytes);
+    TEST("mismatch: keygen K=0", rc == XMSS_OK);
+
+    rc = xmss_sign(&t.p, t.sig, msg, sizeof(msg), t.sk, t.state, 2);
+    TEST("mismatch: sign K=2 after keygen K=0 rejected", rc == XMSS_ERR_PARAMS);
+
+    /* Keygen with K=2, sign with K=4 */
+    test_rng_reset(20);
+    rc = xmss_keygen(&t.p, t.pk, t.sk, t.state, 2, test_randombytes);
+    TEST("mismatch: keygen K=2", rc == XMSS_OK);
+
+    rc = xmss_sign(&t.p, t.sig, msg, sizeof(msg), t.sk, t.state, 4);
+    TEST("mismatch: sign K=4 after keygen K=2 rejected", rc == XMSS_ERR_PARAMS);
+
+    /* Keygen with K=2, sign with K=0 */
+    test_rng_reset(30);
+    rc = xmss_keygen(&t.p, t.pk, t.sk, t.state, 2, test_randombytes);
+    TEST("mismatch: keygen K=2 (2)", rc == XMSS_OK);
+
+    rc = xmss_sign(&t.p, t.sig, msg, sizeof(msg), t.sk, t.state, 0);
+    TEST("mismatch: sign K=0 after keygen K=2 rejected", rc == XMSS_ERR_PARAMS);
+
+    xmss_test_ctx_free(&t);
+}
+
+/* ------------------------------------------------------------------ */
+/* Issue #18: MT sign with mismatched bds_k must be rejected          */
+/* ------------------------------------------------------------------ */
+static void test_bds_k_mt_sign_mismatch(void)
+{
+    xmss_mt_test_ctx t;
+    uint8_t msg[] = { 0x01, 0x02 };
+    int rc;
+
+    xmss_mt_test_ctx_init(&t, OID_XMSS_MT_SHA2_20_2_256);
+
+    /* Keygen with K=0, sign with K=2 */
+    test_rng_reset(50);
+    rc = xmss_mt_keygen(&t.p, t.pk, t.sk, t.state, 0, test_randombytes);
+    TEST("MT mismatch: keygen K=0", rc == XMSS_OK);
+
+    rc = xmss_mt_sign(&t.p, t.sig, msg, sizeof(msg), t.sk, t.state, 2);
+    TEST("MT mismatch: sign K=2 after keygen K=0 rejected", rc == XMSS_ERR_PARAMS);
+
+    /* Keygen with K=2, sign with K=0 */
+    test_rng_reset(60);
+    rc = xmss_mt_keygen(&t.p, t.pk, t.sk, t.state, 2, test_randombytes);
+    TEST("MT mismatch: keygen K=2", rc == XMSS_OK);
+
+    rc = xmss_mt_sign(&t.p, t.sig, msg, sizeof(msg), t.sk, t.state, 0);
+    TEST("MT mismatch: sign K=0 after keygen K=2 rejected", rc == XMSS_ERR_PARAMS);
+
+    xmss_mt_test_ctx_free(&t);
+}
+
+/* ------------------------------------------------------------------ */
+/* Serialize with invalid bds_k must be rejected                      */
+/* ------------------------------------------------------------------ */
+static void test_bds_k_serialize_invalid(void)
+{
+    xmss_test_ctx t;
+    int rc;
+    uint8_t buf[8192]; /* large enough for any serialized BDS state */
+
+    xmss_test_ctx_init(&t, OID_XMSS_SHA2_10_256);
+
+    /* Keygen with valid K=0 to get a state */
+    test_rng_reset(40);
+    rc = xmss_keygen(&t.p, t.pk, t.sk, t.state, 0, test_randombytes);
+    TEST("serialize: keygen K=0", rc == XMSS_OK);
+
+    /* Serialize with invalid K=6 */
+    rc = xmss_bds_serialize(&t.p, buf, t.state, 6);
+    TEST("serialize: K=6 rejected", rc == XMSS_ERR_PARAMS);
+
+    /* Deserialize with invalid K=6 */
+    rc = xmss_bds_deserialize(&t.p, t.state, buf, 6);
+    TEST("deserialize: K=6 rejected", rc == XMSS_ERR_PARAMS);
+
+    xmss_test_ctx_free(&t);
+}
+
 int main(void)
 {
     printf("=== test_bds (BDS-specific parameters) ===\n");
 
     printf("--- bds_k validation ---\n");
     test_bds_k_validation();
+
+    printf("--- bds_k sign mismatch ---\n");
+    test_bds_k_sign_mismatch();
+
+    printf("--- bds_k MT sign mismatch ---\n");
+    test_bds_k_mt_sign_mismatch();
+
+    printf("--- bds_k serialize validation ---\n");
+    test_bds_k_serialize_invalid();
 
     printf("--- roundtrip (k=2) ---\n");
     test_roundtrip_k(OID_XMSS_SHA2_10_256,  "XMSS-SHA2_10_256",  2);


### PR DESCRIPTION
## Summary

Closes #12, closes #18.

- **#12 (security)**: `bds_k` was never checked against `XMSS_MAX_BDS_K`. A caller passing e.g. `bds_k=6` with `tree_height=10` passed all existing checks but overflowed the retain array (sized for `XMSS_MAX_BDS_K=4`).
- **#18 (bug)**: `xmss_sign` and `xmss_mt_sign` accepted `bds_k` as a parameter but never validated it. A caller could pass a different value than keygen, silently corrupting BDS state.

### Changes

- **`bds_k_valid()` helper** (static inline in `xmss.h`): centralises all validation including the new `XMSS_MAX_BDS_K` upper-bound check. Replaces inline checks in keygen functions.
- **`bds_k` field in `xmss_bds_state`**: set at keygen and deserialize; checked at sign time to detect keygen/sign mismatch. Added at end of struct to avoid shifting offsets. Not serialized (caller already knows it).
- **Sign validation**: both `xmss_sign` and `xmss_mt_sign` now validate bounds and check for mismatch before touching any state.
- **Serialize/deserialize validation**: `xmss_bds_serialize` and `xmss_bds_deserialize` reject invalid `bds_k`. Defense-in-depth assert in `xmss_bds_serialized_size`.
- **Tests**: K=6 and K=MAX+2 rejection, keygen/sign mismatch (3 combinations), serialize/deserialize with invalid K.

All 14 C tests pass (86 BDS-specific assertions). No serialization format change. Jasmin unaffected (`BDS_K` is a compile-time constant there).

## Test plan

- [x] `make test` — all 14 tests pass locally
- [ ] CI: gcc + clang with `-Werror`
- [ ] CI: Jasmin interop (no format change, should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)