### PR TITLE
Trivial cleanups: unused var, PROJECT_SOURCE_DIR, libjade URL, ADRS comments (#33, #41, #24, #35, #40)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/post-quantum-cryptography/KAT
 [submodule "third_party/libjade"]
 	path = third_party/libjade
-	url = git@github.com:formosa-crypto/libjade.git
+	url = https://github.com/formosa-crypto/libjade.git

--- a/impl/c/CMakeLists.txt
+++ b/impl/c/CMakeLists.txt
@@ -55,9 +55,9 @@ add_library(xmss STATIC
 )
 
 target_include_directories(xmss PUBLIC
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_SOURCE_DIR}/src/hash
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/src/hash
 )
 
 # -----------------------------------------------------------------------

--- a/impl/c/src/address.c
+++ b/impl/c/src/address.c
@@ -14,7 +14,7 @@
 #include "../include/xmss/types.h"
 #include "address.h"
 
-/* Encode a 32-bit value in big-endian into a word slot */
+/* Store a 32-bit value in a word slot (native; serialised big-endian by xmss_adrs_to_bytes) */
 static void set_word(xmss_adrs_t *a, uint32_t idx, uint32_t val)
 {
     a->w[idx] = val;
@@ -36,10 +36,10 @@ void xmss_adrs_set_type(xmss_adrs_t *a, uint32_t type)
 {
     set_word(a, 3, type);
     /* RFC 8391 §2.5: zero type-specific fields on type change */
-    a->w[4] = 0;
-    a->w[5] = 0;
-    a->w[6] = 0;
-    a->w[7] = 0;
+    set_word(a, 4, 0);
+    set_word(a, 5, 0);
+    set_word(a, 6, 0);
+    set_word(a, 7, 0);
 }
 
 /* OTS address: word 4 = OTS address */

--- a/impl/c/src/wots.c
+++ b/impl/c/src/wots.c
@@ -31,7 +31,6 @@ static void base_w(const xmss_params *p,
                    const uint8_t *in)
 {
     uint32_t in_off  = 0;
-    uint32_t out_off = 0;
     uint32_t total   = 0;
     uint32_t bits    = 0;
     uint32_t consumed;
@@ -42,10 +41,9 @@ static void base_w(const xmss_params *p,
             total = in[in_off++];
             bits  = 8;
         }
-        bits  -= p->log2_w;
-        out[out_off++] = (total >> bits) & mask;
+        bits       -= p->log2_w;
+        out[consumed] = (total >> bits) & mask;
     }
-    (void)out_off;
 }
 
 /* ====================================================================


### PR DESCRIPTION
## Summary

Five independent trivial cleanups, grouped into one PR.

- **#33** `wots.c` `base_w`: remove redundant `out_off` variable — `consumed` already serves as the output index; drop the `(void)out_off` suppression hack too.
- **#41** `impl/c/CMakeLists.txt`: `CMAKE_SOURCE_DIR` → `PROJECT_SOURCE_DIR` — the correct variable when `impl/c/` is built as a CMake subdirectory.
- **#24** `.gitmodules`: change libjade submodule URL from SSH (`git@github.com:...`) to HTTPS, matching all other submodules and enabling unauthenticated CI clones.
- **#35** `address.c` `set_word` comment: the old comment said "big-endian" but the struct stores values in native byte order; big-endian serialisation happens only in `xmss_adrs_to_bytes`.
- **#40** `address.c` `set_type`: replace direct `a->w[4-7] = 0` assignments with `set_word()` calls, consistent with every other setter in the file.

## Test plan

- [ ] CI passes (gcc + clang `-Werror`, all test tiers) — no functional change, but confirms no regression from the wots.c touch and that `PROJECT_SOURCE_DIR` resolves correctly.
- [ ] RISC-V cross-compile CI passes (Thursday scheduled or manual trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)