### PR TITLE
C tests: split test_bds_exhaustive into h5 (core) and h10 (deep) binaries

### DIFF
--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build
         run: cmake --build build
 
-      - name: Exhaustive BDS test (H=5 K=0,2,4 + H=10 K=0,2,4)
-        run: ctest --test-dir build --output-on-failure -R test_bds_exhaustive
+      - name: Exhaustive BDS test (H=5 K=0 + H=10 K=0,2,4)
+        run: ctest --test-dir build --output-on-failure -R test_bds_exhaustive_h
         timeout-minutes: 30
 
   # Jasmin: slow API tests (h=16 ~10min, h=20 ~3h)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ GitHub Actions CI runs on every push and PR:
 - **`ci.yml`** (every push/PR, ~10 min):
   - **C (native)**: gcc + clang (`-Werror`), three-tier test organisation:
     - Tier 1 "fast" (< 30s): params, address, hash, wots, utils — fail fast.
-    - Tier 2 "core" (< 5 min): sign/verify roundtrips, BDS serial, BDS exhaustive (H=5+H=10), XMSS-MT boundary.
+    - Tier 2 "core" (< 5 min): sign/verify roundtrips, BDS serial, BDS exhaustive H=5, XMSS-MT boundary.
     - Tier 3 "deep" (5-15 min): KAT (512 sigs), XMSS-MT KAT, ACVP cross-checks.
   - **Jasmin**: build job (compile + CT checks) → three parallel test jobs via artifact sharing:
     - `jasmin-unit`: 9 unit tests (seconds)
@@ -72,7 +72,9 @@ The following defences are in place:
 
 1. **Treehash completion assertion** (C, `bds.c`): `assert(treehash[i].completed)` before consuming the node in `bds_round()`. Active in debug builds (`NDEBUG`), zero cost in release. Catches budget starvation at the point of corruption.
 
-2. **Exhaustive (H, K) matrix** (C, `test_bds_exhaustive.c`): Signs and verifies EVERY index through a full tree for 4 (H, K) combos — H=5 K=0 (32 sigs, <1s; the only valid K for H=5) and H=10 K=0/2/4 (1024 sigs each, ~2-4 min). Includes post-sign BDS state validation and key exhaustion checks.
+2. **Exhaustive (H, K) matrix** (C, split into two binaries): Signs and verifies EVERY index through a full tree.
+   - `test_bds_exhaustive_h5.c` (core tier, <1s): H=5 K=0 via XMSS-MT 20/4 tree_height=5 — 32 sigs. The only valid K for H=5.
+   - `test_bds_exhaustive_h10.c` (deep tier, ~10 min): H=10 K=0/2/4 via XMSS-SHA2_10_256 — 1024 sigs each. Includes post-sign BDS state validation and key exhaustion checks.
 
 3. **Deep cross-implementation interop** (Jasmin, `test_interop_deep_xmss_sha2_10_256.c`): Signs 64 messages with both C and Jasmin from the same seed. After EACH signature, compares:
    - Signatures byte-for-byte (auth path divergence = BDS state bug)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ The following defences are in place:
 1. **Treehash completion assertion** (C, `bds.c`): `assert(treehash[i].completed)` before consuming the node in `bds_round()`. Active in debug builds (`NDEBUG`), zero cost in release. Catches budget starvation at the point of corruption.
 
 2. **Exhaustive (H, K) matrix** (C, split into two binaries): Signs and verifies EVERY index through a full tree.
-   - `test_bds_exhaustive_h5.c` (core tier, <1s): H=5 K=0 via XMSS-MT 20/4 tree_height=5 — 32 sigs. The only valid K for H=5.
+   - `test_bds_exhaustive_h5.c` (core tier, <1s): H=5 K=0 via XMSS-MT 20/4 tree_height=5 — 33 sigs (32 + 1 boundary crossing). The only valid K for H=5.
    - `test_bds_exhaustive_h10.c` (deep tier, ~10 min): H=10 K=0/2/4 via XMSS-SHA2_10_256 — 1024 sigs each. Includes post-sign BDS state validation and key exhaustion checks.
 
 3. **Deep cross-implementation interop** (Jasmin, `test_interop_deep_xmss_sha2_10_256.c`): Signs 64 messages with both C and Jasmin from the same seed. After EACH signature, compares:

--- a/impl/c/CLAUDE.md
+++ b/impl/c/CLAUDE.md
@@ -131,6 +131,8 @@ These are enforced and must not be broken by any change:
 | `test_xmss_kat` | SHAKE128-fingerprint cross-validation against xmss-reference for 4 XMSS parameter sets: SHA-2/SHAKE × n=32/n=64, h=10 (advances BDS to idx=512 for sig fingerprint) |
 | `test_bds` | BDS-specific: bds_k validation (odd/too-large rejected); roundtrip and sequential signing with bds_k=2 and bds_k=4 |
 | `test_bds_serial` | BDS serialization: round-trip after keygen, mid-signing, byte-exact, size consistency, multiple param sets, bds_k=2 |
+| `test_bds_exhaustive_h5` | Exhaustive H=5 (core tier): all 33 sigs via XMSS-MT 20/4 tree_height=5 with K=0, including layer boundary crossing; treehash completion assertion active in debug builds |
+| `test_bds_exhaustive_h10` | Exhaustive H=10 (deep tier): all 1024 sigs × K=0,2,4 via XMSS-SHA2_10_256; per-signature BDS state invariant validation; key exhaustion check |
 | `test_xmss_mt_params` | All 32 XMSS-MT OIDs: n, w, h, d, tree_height, len, sig_bytes, pk_bytes, sk_bytes, idx_bytes; RFC and internal OID lookup |
 | `test_xmss_mt` | XMSS-MT keygen/sign/verify roundtrip; bit-flip and wrong-message rejection; sequential signing (5 sigs); tree boundary crossing (1024+ sigs) |
 | `test_utils_internal` | ct_memcmp, ull_to_bytes, bytes_to_ull, xmss_memzero, xmss_PRF_idx, key exhaustion |

--- a/impl/c/test/CMakeLists.txt
+++ b/impl/c/test/CMakeLists.txt
@@ -49,24 +49,23 @@ add_xmss_test(test_xmss)
 add_xmss_test(test_bds)
 add_xmss_test(test_bds_serial)
 add_xmss_test(test_xmss_mt)
+# H=5 exhaustive: 32 sigs via XMSS-MT 20/4 tree_height=5, K=0 only (<1s)
+add_xmss_test(test_bds_exhaustive_h5)
 
 set_tests_properties(
-    test_xmss test_bds test_bds_serial test_xmss_mt
+    test_xmss test_bds test_bds_serial test_xmss_mt test_bds_exhaustive_h5
     PROPERTIES LABELS "core"
 )
-
-# test_bds_exhaustive has fast H=5 subtests (<5s) and slow H=10 subtests (~10 min).
-# Label it "core" because the H=5 portion alone catches the important bugs.
-add_xmss_test(test_bds_exhaustive)
-set_tests_properties(test_bds_exhaustive PROPERTIES LABELS "core")
 
 # Tier 3: deep validation (5-15 min total)
 add_xmss_test(test_xmss_kat)
 add_xmss_test(test_xmss_mt_kat     ${CMAKE_SOURCE_DIR}/src/hash)
 add_xmss_test(test_xmss_acvp_kat)
+# H=10 exhaustive: 1024 sigs x K=0,2,4 (~10 min)
+add_xmss_test(test_bds_exhaustive_h10)
 
 set_tests_properties(
-    test_xmss_kat test_xmss_mt_kat test_xmss_acvp_kat
+    test_xmss_kat test_xmss_mt_kat test_xmss_acvp_kat test_bds_exhaustive_h10
     PROPERTIES LABELS "deep"
 )
 
@@ -82,11 +81,11 @@ set_tests_properties(
     PROPERTIES TIMEOUT ${FAST_TIMEOUT}
 )
 set_tests_properties(
-    test_xmss test_bds test_bds_serial test_xmss_mt
+    test_xmss test_bds test_bds_serial test_xmss_mt test_bds_exhaustive_h5
     PROPERTIES TIMEOUT ${CORE_TIMEOUT}
 )
 set_tests_properties(
-    test_bds_exhaustive
+    test_bds_exhaustive_h10
     PROPERTIES TIMEOUT ${EXHAUSTIVE_TIMEOUT}
 )
 set_tests_properties(

--- a/impl/c/test/test_bds_exhaustive_h10.c
+++ b/impl/c/test/test_bds_exhaustive_h10.c
@@ -1,23 +1,22 @@
 /**
- * test_bds_exhaustive.c - Exhaustive BDS (H,K) matrix tests
+ * test_bds_exhaustive_h10.c - Exhaustive BDS H=10 test (slow, labelled "deep")
  *
- * Signs and verifies EVERY index from 0 to 2^H-1 for each feasible (H,K)
- * combination, exercising the full BDS state machine including:
+ * Signs and verifies ALL 1024 indices for H=10 via XMSS-SHA2_10_256 for each
+ * of K=0, K=2, K=4 — covering all valid even K values (H-K = 10, 8, 6).
+ *
+ * Exercises:
  *   - All treehash completion/consumption cycles
  *   - All retain node usage patterns
  *   - High-tau events (idx = 2^k - 1)
  *   - BDS exhaustion edge cases (treehash reinit when startidx >= 2^H)
+ *   - BDS state invariant validation after every signature
  *
  * The treehash completion assertion in bds.c (active in debug builds) provides
  * the invariant check: if any treehash instance is consumed before completion,
  * the process aborts with a clear message.
  *
- * Test matrix:
- *   H=5  via XMSS-MT 20/4 (tree_height=5): K=0 only — 32 sigs
- *         (K=0 is the only valid value for H=5: no even K>0 gives even H-K)
- *   H=10 via XMSS single-tree:              K=0, K=2, K=4  — 1024 sigs each
- *
- * H=5 tests are fast (<1s).  H=10 tests are slow (~2-4 min each).
+ * Runs in ~10 minutes (1024 sigs x 3 K values).  Part of the "deep" tier.
+ * See test_bds_exhaustive_h5.c for the fast H=5 core tests.
  */
 #include <stdio.h>
 #include <stdint.h>
@@ -158,79 +157,11 @@ static void test_xmss_full_tree(uint32_t oid, const char *name, uint32_t bds_k)
     xmss_test_ctx_free(&t);
 }
 
-/* ====================================================================
- * Full-tree XMSS-MT test (uses tree_height from the MT param set)
- *
- * This exercises the per-layer BDS with tree_height=5 (for 20/4).
- * We sign through one full layer-0 tree boundary to exercise both
- * the BDS state machine and the XMSS-MT layer-crossing logic.
- * ==================================================================== */
-static void test_xmss_mt_full_tree(uint32_t oid, const char *name, uint32_t bds_k)
-{
-    xmss_mt_test_ctx t;
-    char label[384];
-    int rc;
-    uint32_t tree_size, i;
-
-    xmss_mt_test_ctx_init(&t, oid);
-    tree_size = (uint32_t)1 << t.p.tree_height;
-
-    printf("\n--- %s K=%u tree_height=%u: signing all %u + 1 indices ---\n",
-           name, bds_k, t.p.tree_height, tree_size);
-
-    test_rng_reset(0xAE00ULL + bds_k);
-    rc = xmss_mt_keygen(&t.p, t.pk, t.sk, t.state, bds_k, test_randombytes);
-    snprintf(label, sizeof(label), "%s K=%u keygen", name, bds_k);
-    TEST(label, rc == XMSS_OK);
-    if (rc != XMSS_OK) { xmss_mt_test_ctx_free(&t); return; }
-
-    /* Sign through one full tree boundary (tree_size + 1 sigs).
-     * The +1 crosses the layer-0 boundary and exercises layer-1. */
-    for (i = 0; i < tree_size + 1; i++) {
-        uint8_t msg[4];
-        msg[0] = (uint8_t)(i >> 0);
-        msg[1] = (uint8_t)(i >> 8);
-        msg[2] = (uint8_t)(i >> 16);
-        msg[3] = (uint8_t)(i >> 24);
-
-        rc = xmss_mt_sign(&t.p, t.sig, msg, sizeof(msg), t.sk, t.state, bds_k);
-        if (rc != XMSS_OK) {
-            snprintf(label, sizeof(label), "%s K=%u sign idx=%u", name, bds_k, i);
-            TEST(label, 0);
-            break;
-        }
-
-        /* Verify every signature */
-        rc = xmss_mt_verify(&t.p, msg, sizeof(msg), t.sig, t.pk);
-        if (rc != XMSS_OK) {
-            snprintf(label, sizeof(label), "%s K=%u verify idx=%u", name, bds_k, i);
-            TEST(label, 0);
-            break;
-        }
-    }
-
-    snprintf(label, sizeof(label), "%s K=%u: all %u signatures verified",
-             name, bds_k, tree_size + 1);
-    TEST(label, i == tree_size + 1);
-
-    xmss_mt_test_ctx_free(&t);
-}
-
 int main(void)
 {
-    printf("=== test_bds_exhaustive: full (H,K) matrix ===\n");
+    printf("=== test_bds_exhaustive_h10: H=10 (XMSS-SHA2_10_256) ===\n");
 
-    /* ---- H=5 via XMSS-MT 20/4 (tree_height=5) ---- */
-    /* K=0 is the only valid value for H=5: no even K>0 gives even (H-K).
-     * K=2 would give H-K=3 (odd), K=4 would give H-K=1 (odd). */
-
-    printf("\n========== H=5 (XMSS-MT 20/4, tree_height=5) ==========\n");
-    test_xmss_mt_full_tree(OID_XMSS_MT_SHA2_20_4_256, "XMSSMT-SHA2_20/4_256", 0);
-
-    /* ---- H=10 via XMSS single-tree ---- */
-    /* These are slow: 1024 sigs each, ~2-4 min */
-    /* H-K = 10 (even), 8 (even), 6 (even) — complementary to H=5 */
-
+    /* H-K = 10 (even), 8 (even), 6 (even) — all valid K values for H=10 */
     printf("\n========== H=10 (XMSS-SHA2_10_256) ==========\n");
     test_xmss_full_tree(OID_XMSS_SHA2_10_256, "XMSS-SHA2_10_256", 0);
     test_xmss_full_tree(OID_XMSS_SHA2_10_256, "XMSS-SHA2_10_256", 2);

--- a/impl/c/test/test_bds_exhaustive_h5.c
+++ b/impl/c/test/test_bds_exhaustive_h5.c
@@ -8,7 +8,11 @@
  *   - All treehash completion/consumption cycles
  *   - All retain node usage patterns
  *   - High-tau events (idx = 2^k - 1)
- *   - BDS exhaustion edge cases
+ *   - Layer boundary crossing (layer-0 tree exhaustion triggers layer-1)
+ *
+ * Note: no explicit XMSS_ERR_EXHAUSTED check — the MT API exhausts the
+ * layer-0 tree at index 32 and advances to layer-1 naturally, so exhaustion
+ * is exercised structurally rather than by an error-return assertion.
  *
  * The treehash completion assertion in bds.c (active in debug builds) provides
  * the invariant check: if any treehash instance is consumed before completion,

--- a/impl/c/test/test_bds_exhaustive_h5.c
+++ b/impl/c/test/test_bds_exhaustive_h5.c
@@ -1,0 +1,97 @@
+/**
+ * test_bds_exhaustive_h5.c - Exhaustive BDS H=5 test (fast, labelled "core")
+ *
+ * Signs and verifies ALL 32 indices for H=5 via XMSS-MT 20/4 (tree_height=5)
+ * with K=0 (the only valid value for H=5: no even K>0 gives even H-K).
+ *
+ * Exercises:
+ *   - All treehash completion/consumption cycles
+ *   - All retain node usage patterns
+ *   - High-tau events (idx = 2^k - 1)
+ *   - BDS exhaustion edge cases
+ *
+ * The treehash completion assertion in bds.c (active in debug builds) provides
+ * the invariant check: if any treehash instance is consumed before completion,
+ * the process aborts with a clear message.
+ *
+ * Runs in < 1 s.  Part of the "core" tier.
+ * See test_bds_exhaustive_h10.c for the slow H=10 deep tests.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "test_utils.h"
+#include "../include/xmss/params.h"
+#include "../include/xmss/xmss.h"
+
+/* ====================================================================
+ * Full-tree XMSS-MT test (uses tree_height from the MT param set)
+ *
+ * This exercises the per-layer BDS with tree_height=5 (for 20/4).
+ * We sign through one full layer-0 tree boundary to exercise both
+ * the BDS state machine and the XMSS-MT layer-crossing logic.
+ * ==================================================================== */
+static void test_xmss_mt_full_tree(uint32_t oid, const char *name, uint32_t bds_k)
+{
+    xmss_mt_test_ctx t;
+    char label[384];
+    int rc;
+    uint32_t tree_size, i;
+
+    xmss_mt_test_ctx_init(&t, oid);
+    tree_size = (uint32_t)1 << t.p.tree_height;
+
+    printf("\n--- %s K=%u tree_height=%u: signing all %u + 1 indices ---\n",
+           name, bds_k, t.p.tree_height, tree_size);
+
+    test_rng_reset(0xAE00ULL + bds_k);
+    rc = xmss_mt_keygen(&t.p, t.pk, t.sk, t.state, bds_k, test_randombytes);
+    snprintf(label, sizeof(label), "%s K=%u keygen", name, bds_k);
+    TEST(label, rc == XMSS_OK);
+    if (rc != XMSS_OK) { xmss_mt_test_ctx_free(&t); return; }
+
+    /* Sign through one full tree boundary (tree_size + 1 sigs).
+     * The +1 crosses the layer-0 boundary and exercises layer-1. */
+    for (i = 0; i < tree_size + 1; i++) {
+        uint8_t msg[4];
+        msg[0] = (uint8_t)(i >> 0);
+        msg[1] = (uint8_t)(i >> 8);
+        msg[2] = (uint8_t)(i >> 16);
+        msg[3] = (uint8_t)(i >> 24);
+
+        rc = xmss_mt_sign(&t.p, t.sig, msg, sizeof(msg), t.sk, t.state, bds_k);
+        if (rc != XMSS_OK) {
+            snprintf(label, sizeof(label), "%s K=%u sign idx=%u", name, bds_k, i);
+            TEST(label, 0);
+            break;
+        }
+
+        /* Verify every signature */
+        rc = xmss_mt_verify(&t.p, msg, sizeof(msg), t.sig, t.pk);
+        if (rc != XMSS_OK) {
+            snprintf(label, sizeof(label), "%s K=%u verify idx=%u", name, bds_k, i);
+            TEST(label, 0);
+            break;
+        }
+    }
+
+    snprintf(label, sizeof(label), "%s K=%u: all %u signatures verified",
+             name, bds_k, tree_size + 1);
+    TEST(label, i == tree_size + 1);
+
+    xmss_mt_test_ctx_free(&t);
+}
+
+int main(void)
+{
+    printf("=== test_bds_exhaustive_h5: H=5 (XMSS-MT 20/4) ===\n");
+
+    /* K=0 is the only valid value for H=5: no even K>0 gives even (H-K).
+     * K=2 would give H-K=3 (odd), K=4 would give H-K=1 (odd). */
+    printf("\n========== H=5 (XMSS-MT 20/4, tree_height=5) ==========\n");
+    test_xmss_mt_full_tree(OID_XMSS_MT_SHA2_20_4_256, "XMSSMT-SHA2_20/4_256", 0);
+
+    return tests_done();
+}


### PR DESCRIPTION
Fixes #19.

## Summary

- Split `test_bds_exhaustive.c` into two binaries to restore the tier contract:
  - **`test_bds_exhaustive_h5`** (core tier, `CORE_TIMEOUT`): H=5 K=0 via XMSS-MT 20/4, 32 sigs — runs in <1s, catches BDS state machine bugs fast
  - **`test_bds_exhaustive_h10`** (deep tier, `EXHAUSTIVE_TIMEOUT`): H=10 K=0/2/4 via XMSS-SHA2_10_256, 1024 sigs each — full ~10min deep validation
- `ctest -L core` is now back under 5 minutes
- Fixed `ci-scheduled.yml` step name: "H=5 K=0,2,4" → "H=5 K=0 + H=10 K=0,2,4" (K=2/4 are invalid for H=5; H-K must be even)
- Updated `ctest -R` regex in the scheduled workflow from `test_bds_exhaustive` to `test_bds_exhaustive_h` to match both new binaries

## Test plan

- [ ] `ctest -L core` completes in < 5 min (h5 binary is seconds)
- [ ] `ctest -L deep` includes `test_bds_exhaustive_h10`
- [ ] `ctest -R test_bds_exhaustive_h` matches both binaries
- [ ] CI passes (per-push `ci.yml` runs both tiers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)