### PR TITLE
Security hardening: secret zeroing, volatile barriers, CI permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/jasmin_check.sh"
+            "command": "$PROJECT_DIR/.claude/hooks/jasmin_check.sh"
           }
         ]
       }

--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -7,6 +7,9 @@ on:
     - cron: '0 4 * * 4'  # Thursday 04:00 UTC — RISC-V
   workflow_dispatch:       # Manual trigger (runs all jobs)
 
+permissions:
+  contents: read
+
 jobs:
   # C: full exhaustive BDS matrix (H=5 and H=10, all K values)
   # Catches treehash budget bugs across every (H,K) combination.
@@ -24,7 +27,7 @@ jobs:
       run:
         working-directory: impl/c
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure (debug — enables assertions)
         run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DXMSS_WERROR=ON
@@ -46,10 +49,10 @@ jobs:
       run:
         working-directory: impl/jasmin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up OCaml
-        uses: ocaml/setup-ocaml@v3
+        uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3
         with:
           ocaml-compiler: "4.14"
 
@@ -80,7 +83,7 @@ jobs:
       run:
         working-directory: impl/c
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install cross toolchain
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     paths-ignore:
       - '**/*.md'
 
+permissions:
+  contents: read
+
 jobs:
   native:
     name: ${{ matrix.cc }}
@@ -22,7 +25,7 @@ jobs:
       run:
         working-directory: impl/c
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DXMSS_WERROR=ON
@@ -47,10 +50,10 @@ jobs:
       run:
         working-directory: impl/jasmin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up OCaml
-        uses: ocaml/setup-ocaml@v3
+        uses: ocaml/setup-ocaml@e32b06a3e831ff2fbc6f08cf35be2085e3918014 # v3
         with:
           ocaml-compiler: "4.14"
 
@@ -70,7 +73,7 @@ jobs:
         run: opam exec -- make ct
 
       - name: Upload test binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jasmin-test-binaries
           path: impl/jasmin/build/test/
@@ -83,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download test binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: jasmin-test-binaries
           path: bin
@@ -107,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download test binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: jasmin-test-binaries
           path: bin
@@ -125,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download test binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: jasmin-test-binaries
           path: bin

--- a/impl/c/src/hash/xmss_hash.c
+++ b/impl/c/src/hash/xmss_hash.c
@@ -76,6 +76,8 @@ static void prf_local(const xmss_params *p, uint8_t *out,
     off += 32;
 
     core_hash_local(p, out, buf, off);
+    xmss_memzero(buf, sizeof(buf));
+    xmss_memzero(adrs_bytes, sizeof(adrs_bytes));
 }
 
 /* ====================================================================
@@ -114,6 +116,9 @@ int xmss_F(const xmss_params *p, uint8_t *out,
     for (i = 0; i < p->n; i++) { buf[off++] = in[i] ^ bm[i]; }
 
     core_hash_local(p, out, buf, off);
+    xmss_memzero(prf_key, sizeof(prf_key));
+    xmss_memzero(bm, sizeof(bm));
+    xmss_memzero(buf, sizeof(buf));
     return 0;
 }
 
@@ -160,6 +165,10 @@ int xmss_H(const xmss_params *p, uint8_t *out,
     for (i = 0; i < p->n; i++) { buf[off++] = in_r[i] ^ bm_r[i]; }
 
     core_hash_local(p, out, buf, off);
+    xmss_memzero(prf_key, sizeof(prf_key));
+    xmss_memzero(bm_l, sizeof(bm_l));
+    xmss_memzero(bm_r, sizeof(bm_r));
+    xmss_memzero(buf, sizeof(buf));
     return 0;
 }
 
@@ -276,6 +285,8 @@ int xmss_PRF_keygen(const xmss_params *p, uint8_t *out,
     memcpy(buf + off, adrs_bytes, 32); off += 32;
 
     core_hash_local(p, out, buf, off);
+    xmss_memzero(buf, sizeof(buf));
+    xmss_memzero(adrs_bytes, sizeof(adrs_bytes));
     return 0;
 }
 
@@ -302,5 +313,6 @@ int xmss_PRF_idx(const xmss_params *p, uint8_t *out,
     off += 32;
 
     core_hash_local(p, out, buf, off);
+    xmss_memzero(buf, sizeof(buf));
     return 0;
 }

--- a/impl/c/src/utils.c
+++ b/impl/c/src/utils.c
@@ -48,9 +48,11 @@ uint64_t bytes_to_ull(const uint8_t *in, uint32_t len)
 /**
  * xmss_memzero() - Securely zero len bytes at ptr.
  *
- * Uses the volatile-pointer idiom to prevent the compiler from optimising
- * this away.  Not guaranteed on all compilers, but portable and standard C99.
- * On platforms with memset_s or explicit_bzero, those should be preferred.
+ * Uses the volatile-pointer idiom plus a compiler memory barrier to prevent
+ * the compiler from optimising this away.  The volatile qualifier prevents
+ * dead-store elimination of the writes; the barrier prevents the compiler
+ * from proving the writes are unobservable and removing them at a higher
+ * optimisation level.
  */
 void xmss_memzero(void *ptr, size_t len)
 {
@@ -59,6 +61,7 @@ void xmss_memzero(void *ptr, size_t len)
     for (i = 0; i < len; i++) {
         p[i] = 0;
     }
+    __asm__ __volatile__("" ::: "memory");
 }
 
 /**
@@ -67,6 +70,10 @@ void xmss_memzero(void *ptr, size_t len)
  * Returns 0 if the first len bytes of a and b are identical, non-zero
  * otherwise.  Evaluates all len bytes regardless of early differences
  * (no short-circuit).
+ *
+ * The volatile accumulator prevents dead-store elimination of intermediate
+ * writes to diff.  The compiler memory barrier prevents the compiler from
+ * short-circuiting the loop if it can prove diff is already non-zero.
  *
  * J6: constant-time required for signature verification (prevents timing
  * oracle distinguishing valid from invalid signatures).
@@ -78,5 +85,6 @@ int ct_memcmp(const uint8_t *a, const uint8_t *b, size_t len)
     for (i = 0; i < len; i++) {
         diff |= a[i] ^ b[i];
     }
+    __asm__ __volatile__("" ::: "memory");
     return (int)diff;
 }

--- a/impl/c/src/xmss.c
+++ b/impl/c/src/xmss.c
@@ -128,6 +128,8 @@ int xmss_sign_naive(const xmss_params *p, uint8_t *sig,
                        sk_seed, pub_seed,
                        (uint32_t)idx, &adrs);
 
+    xmss_memzero(r, sizeof(r));
+    xmss_memzero(m_hash, sizeof(m_hash));
     return XMSS_OK;
 }
 
@@ -345,5 +347,7 @@ int xmss_sign(const xmss_params *p, uint8_t *sig,
                             sk_seed, pub_seed, &adrs);
     }
 
+    xmss_memzero(r, sizeof(r));
+    xmss_memzero(m_hash, sizeof(m_hash));
     return XMSS_OK;
 }

--- a/impl/c/src/xmss_mt.c
+++ b/impl/c/src/xmss_mt.c
@@ -297,6 +297,8 @@ int xmss_mt_sign(const xmss_params *p, uint8_t *sig,
         }
     }
 
+    xmss_memzero(r, sizeof(r));
+    xmss_memzero(m_hash, sizeof(m_hash));
     return XMSS_OK;
 }
 


### PR DESCRIPTION
## Summary

- **#13 (secret material not zeroed)**: Add `xmss_memzero()` calls to zero secret-derived stack buffers (`prf_key`, `bm`, `bm_l`, `bm_r`, `buf`, `adrs_bytes`, `r`, `m_hash`) before return in `prf_local`, `xmss_F`, `xmss_H`, `xmss_PRF_keygen`, `xmss_PRF_idx`, `xmss_sign_naive`, `xmss_sign`, and `xmss_mt_sign`.
- **#26 (volatile semantics)**: Add `__asm__ __volatile__("" ::: "memory")` compiler memory barriers after the critical loops in `xmss_memzero` and `ct_memcmp`, complementing the existing `volatile` qualifier against dead-store elimination and loop short-circuiting.
- **#15 (CI hardening)**: Add `permissions: { contents: read }` to both `ci.yml` and `ci-scheduled.yml`; pin all third-party actions (`actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, `ocaml/setup-ocaml`) to commit SHAs.
- **Hook fix**: Use `$PROJECT_DIR` prefix for `jasmin_check.sh` hook path in `.claude/settings.json` to fix "not found" errors when working directory isn't project root.

Closes #13, closes #15, closes #26.

## Test plan

- [x] All 14 C tests pass locally (verified before push)
- [ ] CI passes on both gcc and clang
- [ ] Jasmin interop + KAT tests still pass (no C API change)
- [ ] Verify pinned action SHAs resolve correctly in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)