### PR TITLE
Fix failing scheduled CI: ull_to_bytes assertion and RISC-V QEMU timeout

### DIFF
--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -96,7 +96,7 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-riscv64.cmake
           -DCMAKE_BUILD_TYPE=Release
           -DXMSS_WERROR=ON
-          -DXMSS_TEST_TIMEOUT_SCALE=2
+          -DXMSS_TEST_TIMEOUT_SCALE=4
 
       - name: Build
         run: cmake --build build-rv

--- a/impl/c/src/utils.c
+++ b/impl/c/src/utils.c
@@ -16,13 +16,14 @@
  * ull_to_bytes() - Encode a uint64_t in big-endian into len bytes.
  *
  * RFC 8391 §2.4: toByte(x, n) converts x to an n-byte big-endian string.
- * Writes exactly len bytes; asserts len <= 8 and that val fits in len bytes.
+ * Writes exactly len bytes. n may exceed 8 (e.g. toByte(idx, n) in H_msg and
+ * toByte(idx, 32) in PRF for r): the leading len-8 bytes are zero-padded since
+ * val always fits in 64 bits. For len < 8, asserts val fits in len bytes.
  */
 void ull_to_bytes(uint8_t *out, uint32_t len, uint64_t val)
 {
     uint32_t i;
-    assert(len <= 8);
-    assert(len == 8 || (val >> (len * 8)) == 0);
+    assert(len >= 8 || (val >> (len * 8)) == 0);
     for (i = len; i > 0; i--) {
         out[i - 1] = (uint8_t)(val & 0xFF);
         val >>= 8;


### PR DESCRIPTION
## Summary

Two independent failures in `ci-scheduled.yml`, both long-standing:

### 1. C exhaustive BDS (Sunday, Debug build)
`test_bds_exhaustive_h5` and `test_bds_exhaustive_h10` aborted on `assert(len <= 8)` in `ull_to_bytes` (`impl/c/src/utils.c`).

`ull_to_bytes` implements RFC 8391 `toByte(x, n)`, which is legitimately called with `n > 8`:
- `toByte(idx, n)` in `H_msg` (n = 32 or 64) — `xmss_hash.c:189`
- `toByte(idx, 32)` in PRF for the `r` value — `xmss_hash.c:312`

The value always fits in 64 bits, so the loop already zero-pads the leading bytes correctly — only the assertion was wrong. Relaxed it to check the fit only for `len < 8`. Release CI never caught this because assertions are compiled out; the Debug-build exhaustive job is the only place they run.

### 2. RISC-V (Thursday)
`test_xmss_mt` timed out at 240s under QEMU. QEMU user-mode is ~8.5× slower than native (derived from `test_xmss`: ~205s emulated vs 24s native), so the 31s-native boundary-crossing test needs ~264s — just over the 120s core budget at scale 2. Bumped `XMSS_TEST_TIMEOUT_SCALE` to 4 (480s core budget, ~1.8× margin; also widens the fast-tier margin).

## Test plan
- [x] Debug build `test_bds_exhaustive_h5` passes locally (was aborting before)
- [x] `test_utils_internal` passes (33/33), including `ull_to_bytes` cases
- [ ] Scheduled workflow (verify via manual `workflow_dispatch` after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)